### PR TITLE
Révision du chapitre 1

### DIFF
--- a/src/01-matplotlib.ipynb
+++ b/src/01-matplotlib.ipynb
@@ -455,6 +455,7 @@
     "lang": "fr"
    },
    "source": [
+    "### Bonus - Exemples plus complets\n",
     "Autres particularités de `.plot()` et Matplotlib :\n",
     "* Chaque colonne d'un DataFrame obtient une couleur différente.\n",
     "* Divers arguments et méthodes pour configurer\n",
@@ -468,6 +469,7 @@
     "lang": "en"
    },
    "source": [
+    "### Bonus - More complete examples\n",
     "Other features of `.plot()` and Matplotlib:\n",
     "* Each column of the DataFrame will have a different color.\n",
     "* Various arguments and methods to configure\n",
@@ -541,7 +543,7 @@
     "lang": "fr"
    },
    "source": [
-    "### Exercices - Créer un graphique\n",
+    "### Bonus - Exercices - Créer un graphique\n",
     "`1`. Générez un graphique de courbes montrant le\n",
     "`hindfoot_length` moyen de chaque espèce d'une année à l'autre.\n",
     "Note : les enregistrements sans `hindfoot_length` sont écartés.\n",
@@ -555,7 +557,7 @@
     "lang": "en"
    },
    "source": [
-    "### Exercises - Create a plot\n",
+    "### Bonus - Exercises - Create a plot\n",
     "`1`. Generate a line-plot showing the average\n",
     "`hindfoot_length` of each species from one year to the next.\n",
     "Note: records without an `hindfoot_length` are discarded.\n",

--- a/src/01-matplotlib.ipynb
+++ b/src/01-matplotlib.ipynb
@@ -112,7 +112,8 @@
    "source": [
     "Types Python | Types Pandas | Description\n",
     ":-----------:|:------------:|:-----------\n",
-    "`str`        | `object`     | Type générique, aussi utilisé en cas de multiples types\n",
+    "`str`        | `object`     | (Pandas <3.0.0) Type générique, aussi utilisé en cas de multiples types\n",
+    "`str`   | `str` ou `string` | [Depuis Pandas 3.0.0](https://pandas.pydata.org/docs/user_guide/text.html#text-data-types), `str` est le type par défaut pour du texte\n",
     "`int`        | `int64`      | Nombres entiers représentés avec 64 bits\n",
     "`float`      | `float64`    | Nombres réels représentés avec 64 bits, ou non-définis (NaN)\n",
     " N/A         | `datetime64` | Dates et heures, avec une précision allant jusqu'à la nanoseconde"
@@ -127,7 +128,8 @@
    "source": [
     "Native Python Type | Pandas Type | Description\n",
     ":-----------------:|:-----------:|:-----------\n",
-    "`str`              | `object`    | The most general dtype. Will be assigned to your column if column has mixed types (numbers and strings).\n",
+    "`str`              | `object`    | (Pandas <3.0.0) The most general dtype. Will be assigned to your column if column has mixed types (numbers and strings).\n",
+    "`str`        | `str` or `string` | [Since Pandas 3.0.0](https://pandas.pydata.org/docs/user_guide/text.html#text-data-types), `str` is the default type for text\n",
     "`int`              | `int64`     | 64 bits integer\n",
     "`float`            | `float64`   | Numeric characters with decimals. If a column contains numbers and NaNs(see below), pandas will default to float64.\n",
     " N/A               | `datetime64`| Values meant to hold time data."


### PR DESCRIPTION
Suite au post-mortem de DAT203 en français, il fallait :
- Mentionner le nouveau type Pandas `str`.
- Réduire la partie Matplotlib pour économiser du temps pour Altair, et aussi pour éviter de créer de la confusion entre le fonctionnement des deux bibliothèques.
  - Pour éviter de tout effacer, j'ai mis les sections en "Bonus".